### PR TITLE
auth 모듈 리펙토링 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,29 +2,31 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from '~/src/domain/users/users.module';
-import { ConfigModule,ConfigService } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '~/src/domain/auth/auth.module';
 @Module({
-  imports: [ConfigModule.forRoot({
-    isGlobal: true,
-  }),
-  TypeOrmModule.forRootAsync({
-    imports: [ConfigModule],
-    useFactory: (configService: ConfigService) => ({
-      type: 'postgres',
-      host: configService.get<string>('DB_HOST'),
-      port: configService.get<number>('DB_PORT'),
-      username: configService.get<string>('DB_USERNAME'),
-      password: configService.get<string>('DB_PASSWORD'),
-      database: configService.get<string>('DB_NAME'),
-      autoLoadEntities: true,
-      synchronize: true,
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
     }),
-    inject: [ConfigService],
-  }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        type: 'postgres',
+        host: configService.get<string>('DB_HOST'),
+        port: configService.get<number>('DB_PORT'),
+        username: configService.get<string>('DB_USERNAME'),
+        password: configService.get<string>('DB_PASSWORD'),
+        database: configService.get<string>('DB_NAME'),
+        autoLoadEntities: true,
+        synchronize: true,
+      }),
+      inject: [ConfigService],
+    }),
     UsersModule,
-    AuthModule],
+    AuthModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -34,6 +34,7 @@ export class AuthController {
     return;
   }
 
+  /* TODO: 로직 분리 */
   @UseGuards(KakaoOAuthGuard)
   @Get('kakao/callback')
   async kakaoLoginCallback(@Req() req, @Res() res): Promise<void> {

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -1,22 +1,26 @@
-import { Controller, Get, Req, Res, UseGuards, InternalServerErrorException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Req,
+  Res,
+  UseGuards,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { Request } from '@nestjs/common';
 import { UserDataDto } from '~/src/domain/users/dto/user.dto';
 import { KakaoProfileDto } from './dto/social-profile.dto';
-import { JwtAuthGuard,KakaoOAuthGuard } from './guards/auth.guard';
-
-
+import { JwtAuthGuard, KakaoOAuthGuard } from './guards/auth.guard';
 
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
-  
+
   @Get('terms')
   getTermsPage() {
     /*TODO: 카카오 회원가입을 위해서는 terms 관련 페이지가 필수적임 */
     return 'terms';
   }
-  
+
   @UseGuards(JwtAuthGuard)
   @Get('test')
   getTestPage() {
@@ -26,7 +30,7 @@ export class AuthController {
 
   @UseGuards(KakaoOAuthGuard)
   @Get('kakao')
-  async kakaoLogin(@Req() req: Request) {
+  async kakaoLogin() {
     return;
   }
 
@@ -34,7 +38,7 @@ export class AuthController {
   @Get('kakao/callback')
   async kakaoLoginCallback(@Req() req, @Res() res): Promise<void> {
     // 카카오 인증 완료 후 로그인 처리
-    const kakaoProfile:KakaoProfileDto = req.user;
+    const kakaoProfile: KakaoProfileDto = req.user;
     let user: UserDataDto;
     try {
       user = await this.authService.validateSocialUser(kakaoProfile);

--- a/src/domain/auth/auth.module.ts
+++ b/src/domain/auth/auth.module.ts
@@ -13,7 +13,7 @@ import { AuthController } from './auth.controller';
     PassportModule,
     UsersModule,
     JwtModule.registerAsync({
-      imports:[ConfigModule],
+      imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
         signOptions: { expiresIn: '60s' },
@@ -21,11 +21,8 @@ import { AuthController } from './auth.controller';
       inject: [ConfigService],
     }),
   ],
-  providers: [
-    AuthService,
-    KakaoStrategy,
-    JwtStrategy,
-  ],
+
+  providers: [AuthService, KakaoStrategy, JwtStrategy],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -1,41 +1,44 @@
-import { Injectable} from '@nestjs/common';
-import { UserDataDto,CreateUserDto } from '~/src/domain/users/dto/user.dto';
+import { Injectable } from '@nestjs/common';
+import { UserDataDto, CreateUserDto } from '~/src/domain/users/dto/user.dto';
 import { UsersService } from '~/src/domain/users/users.service';
 import { JwtPayloadDto } from '~/src/domain/auth/dto/jwt.dto';
 import { JwtService } from '@nestjs/jwt';
-import { FindByIdDto,FindBySocialIdDto } from '~/src/domain/users/dto/user.dto';
+import {
+  FindByIdDto,
+  FindBySocialIdDto,
+} from '~/src/domain/users/dto/user.dto';
 import { SocialProfileDto } from '~/src/domain/auth/dto/social-profile.dto';
-
 
 @Injectable()
 export class AuthService {
-    constructor(
-        private readonly usersService: UsersService,
-        private jwtService: JwtService,
-    ){}
-    async login(user:UserDataDto):Promise<string> {
-        const payload:JwtPayloadDto = { 
-          id: user.id, 
-          name: user.name, 
-          email: user.email, 
-          socialType: user.socialType
-         };
-        return this.jwtService.sign(payload);
-    }
-    async createSocialUser(profile: SocialProfileDto) : Promise<UserDataDto> {
-        return this.usersService.create({
-          name: profile.name,
-          /*TODO: password 관련 로직 변경 필요, but 소셜로그인 단계에서는 password관련 로직이 하나도 없기에 일단 방치해도 됨. */
-          password: '!@#$!$%@#',
-          email: profile.email,
-          socialId: profile.socialId,
-          socialType: profile.socialType,
-        } as CreateUserDto);
-      }
-    async validateUser(payload: JwtPayloadDto) : Promise<UserDataDto> {
-        return await this.usersService.findById(payload as FindByIdDto);
-    }
-    async validateSocialUser(profile: SocialProfileDto) : Promise<UserDataDto> {
-        return await this.usersService.findBySocialId(profile as FindBySocialIdDto);
-    }
+  constructor(
+    private readonly usersService: UsersService,
+    private jwtService: JwtService,
+  ) {}
+
+  async login(user: UserDataDto): Promise<string> {
+    const payload: JwtPayloadDto = {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      socialType: user.socialType,
+    };
+    return this.jwtService.sign(payload);
+  }
+  async createSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
+    return this.usersService.create({
+      name: profile.name,
+      /*TODO: password 관련 로직 변경 필요, but 소셜로그인 단계에서는 password관련 로직이 하나도 없기에 일단 방치해도 됨. */
+      password: '!@#$!$%@#',
+      email: profile.email,
+      socialId: profile.socialId,
+      socialType: profile.socialType,
+    } as CreateUserDto);
+  }
+  async validateUser(payload: JwtPayloadDto): Promise<UserDataDto> {
+    return await this.usersService.findById(payload as FindByIdDto);
+  }
+  async validateSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
+    return await this.usersService.findBySocialId(profile as FindBySocialIdDto);
+  }
 }

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -3,11 +3,11 @@ import {
   UserDataDto,
   CreateUserDto,
   FindByDto,
+  UpdateUserDto,
 } from '~/src/domain/users/dto/user.dto';
 import { UsersService } from '~/src/domain/users/users.service';
 import { JwtPayloadDto } from '~/src/domain/auth/dto/jwt.dto';
 import { JwtService } from '@nestjs/jwt';
-
 import { SocialProfileDto } from '~/src/domain/auth/dto/social-profile.dto';
 
 @Injectable()
@@ -45,11 +45,22 @@ export class AuthService {
     const { id } = payload;
     return await this.usersService.findById({ id } as FindByDto);
   }
+  /* TODO: 로직 분리 */
   async validateSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
     const { socialId, socialType } = profile;
-    return await this.usersService.findBySocialId({
+    const user: UserDataDto = await this.usersService.findBySocialId({
       socialId,
       socialType,
     } as FindByDto);
+    if (user) await this.updateSocialUser(profile);
+    return user;
+  }
+  async updateSocialUser(profile: SocialProfileDto): Promise<void> {
+    const { name, profileUrl, thumbnailUrl } = profile;
+    this.usersService.update({
+      name,
+      profileUrl,
+      thumbnailUrl,
+    } as UpdateUserDto);
   }
 }

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -29,7 +29,7 @@ export class AuthService {
     return this.usersService.create({
       name: profile.name,
       /*TODO: password 관련 로직 변경 필요, but 소셜로그인 단계에서는 password관련 로직이 하나도 없기에 일단 방치해도 됨. */
-      password: '!@#$!$%@#',
+      password: 'NOT_DEFINED',
       email: profile.email,
       socialId: profile.socialId,
       socialType: profile.socialType,

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -18,11 +18,12 @@ export class AuthService {
   ) {}
 
   async login(user: UserDataDto): Promise<string> {
+    const { id, name, email, socialType } = user;
     const payload: JwtPayloadDto = {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      socialType: user.socialType,
+      id,
+      name,
+      email,
+      socialType,
     };
     return this.jwtService.sign(payload);
   }

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@nestjs/common';
-import { UserDataDto, CreateUserDto } from '~/src/domain/users/dto/user.dto';
+import {
+  UserDataDto,
+  CreateUserDto,
+  FindByDto,
+} from '~/src/domain/users/dto/user.dto';
 import { UsersService } from '~/src/domain/users/users.service';
 import { JwtPayloadDto } from '~/src/domain/auth/dto/jwt.dto';
 import { JwtService } from '@nestjs/jwt';
-import {
-  FindByIdDto,
-  FindBySocialIdDto,
-} from '~/src/domain/users/dto/user.dto';
+
 import { SocialProfileDto } from '~/src/domain/auth/dto/social-profile.dto';
 
 @Injectable()
@@ -27,20 +28,14 @@ export class AuthService {
   }
   async createSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
     return this.usersService.create({
-      name: profile.name,
-      /*TODO: password 관련 로직 변경 필요, but 소셜로그인 단계에서는 password관련 로직이 하나도 없기에 일단 방치해도 됨. */
       password: 'NOT_DEFINED',
-      email: profile.email,
-      socialId: profile.socialId,
-      socialType: profile.socialType,
-      profile_url: profile.profileUrl,
-      thumbnail_url: profile.thumbnailUrl,
+      ...profile,
     } as CreateUserDto);
   }
   async validateUser(payload: JwtPayloadDto): Promise<UserDataDto> {
-    return await this.usersService.findById(payload as FindByIdDto);
+    return await this.usersService.findById(payload as FindByDto);
   }
   async validateSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
-    return await this.usersService.findBySocialId(profile as FindBySocialIdDto);
+    return await this.usersService.findBySocialId(profile as FindByDto);
   }
 }

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -33,6 +33,8 @@ export class AuthService {
       email: profile.email,
       socialId: profile.socialId,
       socialType: profile.socialType,
+      profile_url: profile.profileUrl,
+      thumbnail_url: profile.thumbnailUrl,
     } as CreateUserDto);
   }
   async validateUser(payload: JwtPayloadDto): Promise<UserDataDto> {

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -28,15 +28,28 @@ export class AuthService {
     return this.jwtService.sign(payload);
   }
   async createSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
+    const { id, name, email, socialId, socialType, profileUrl, thumbnailUrl } =
+      profile;
     return this.usersService.create({
+      id,
+      name,
       password: 'NOT_DEFINED',
-      ...profile,
+      email,
+      socialId,
+      socialType,
+      profileUrl,
+      thumbnailUrl,
     } as CreateUserDto);
   }
   async validateUser(payload: JwtPayloadDto): Promise<UserDataDto> {
-    return await this.usersService.findById(payload as FindByDto);
+    const { id } = payload;
+    return await this.usersService.findById({ id } as FindByDto);
   }
   async validateSocialUser(profile: SocialProfileDto): Promise<UserDataDto> {
-    return await this.usersService.findBySocialId(profile as FindByDto);
+    const { socialId, socialType } = profile;
+    return await this.usersService.findBySocialId({
+      socialId,
+      socialType,
+    } as FindByDto);
   }
 }

--- a/src/domain/auth/dto/jwt.dto.ts
+++ b/src/domain/auth/dto/jwt.dto.ts
@@ -1,13 +1,4 @@
-import { IsString, IsNumber, IsEnum } from 'class-validator';
-import { SocialType } from '~/src/domain/users/enum/social-type.enum';
+import { PartialType } from '@nestjs/mapped-types';
+import { UserDataDto } from '~/src/domain/users/dto/user.dto';
 
-export class JwtPayloadDto {
-  @IsNumber()
-  id: number;
-  @IsString()
-  name: string;
-  @IsString()
-  email: string;
-  @IsEnum(SocialType)
-  socialType: SocialType; //TODO: enum으로 변경
-}
+export class JwtPayloadDto extends PartialType(UserDataDto) {}

--- a/src/domain/auth/dto/jwt.dto.ts
+++ b/src/domain/auth/dto/jwt.dto.ts
@@ -1,12 +1,12 @@
 import { IsString, IsNumber } from 'class-validator';
 
-export class JwtPayloadDto{
-    @IsNumber()
-    id: number;
-    @IsString()
-    name: string;
-    @IsString()
-    email: string; 
-    @IsString()
-    socialType: string; //TODO: enum으로 변경
+export class JwtPayloadDto {
+  @IsNumber()
+  id: number;
+  @IsString()
+  name: string;
+  @IsString()
+  email: string;
+  @IsString()
+  socialType: string; //TODO: enum으로 변경
 }

--- a/src/domain/auth/dto/jwt.dto.ts
+++ b/src/domain/auth/dto/jwt.dto.ts
@@ -1,4 +1,5 @@
-import { IsString, IsNumber } from 'class-validator';
+import { IsString, IsNumber, IsEnum } from 'class-validator';
+import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 
 export class JwtPayloadDto {
   @IsNumber()
@@ -7,6 +8,6 @@ export class JwtPayloadDto {
   name: string;
   @IsString()
   email: string;
-  @IsString()
-  socialType: string; //TODO: enum으로 변경
+  @IsEnum(SocialType)
+  socialType: SocialType; //TODO: enum으로 변경
 }

--- a/src/domain/auth/dto/social-profile.dto.ts
+++ b/src/domain/auth/dto/social-profile.dto.ts
@@ -1,24 +1,23 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
-export class SocialProfileDto{
-    @IsNotEmpty()
-    @IsString()
-    name: string;
+export class SocialProfileDto {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
 
-    @IsNotEmpty()
-    @IsEmail()
-    email: string;
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
 
-    @IsNotEmpty()
-    @IsString() 
-    socialId: string;
-    
-    @IsNotEmpty()
-    @IsString()
-    socialType: string;
+  @IsNotEmpty()
+  @IsString()
+  socialId: string;
 
-    accessToken?: string;
-    refreshToken?: string;
+  @IsNotEmpty()
+  @IsString()
+  socialType: string;
+
+  accessToken?: string;
+  refreshToken?: string;
 }
 
-export class KakaoProfileDto extends SocialProfileDto{
-}
+export class KakaoProfileDto extends SocialProfileDto {}

--- a/src/domain/auth/dto/social-profile.dto.ts
+++ b/src/domain/auth/dto/social-profile.dto.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 export class SocialProfileDto {
   @IsNotEmpty()
   @IsString()
@@ -10,11 +11,11 @@ export class SocialProfileDto {
 
   @IsNotEmpty()
   @IsString()
-  socialId: string;
+  socialId: SocialType;
 
   @IsNotEmpty()
-  @IsString()
-  socialType: string;
+  @IsEnum(SocialType)
+  socialType: SocialType;
 
   accessToken?: string;
   refreshToken?: string;

--- a/src/domain/auth/dto/social-profile.dto.ts
+++ b/src/domain/auth/dto/social-profile.dto.ts
@@ -1,14 +1,9 @@
-import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { UserDataDto } from '~/src/domain/users/dto/user.dto';
 import { SocialType } from '~/src/domain/users/enum/social-type.enum';
-export class SocialProfileDto {
-  @IsNotEmpty()
-  @IsString()
-  name: string;
 
-  @IsNotEmpty()
-  @IsEmail()
-  email: string;
-
+export class SocialProfileDto extends PartialType(UserDataDto) {
   @IsNotEmpty()
   @IsString()
   socialId: SocialType;
@@ -16,11 +11,6 @@ export class SocialProfileDto {
   @IsNotEmpty()
   @IsEnum(SocialType)
   socialType: SocialType;
-
-  @IsString()
-  profileUrl?: string;
-  @IsString()
-  thumbnailUrl?: string;
 
   accessToken?: string;
   refreshToken?: string;

--- a/src/domain/auth/dto/social-profile.dto.ts
+++ b/src/domain/auth/dto/social-profile.dto.ts
@@ -17,6 +17,11 @@ export class SocialProfileDto {
   @IsEnum(SocialType)
   socialType: SocialType;
 
+  @IsString()
+  profileUrl?: string;
+  @IsString()
+  thumbnailUrl?: string;
+
   accessToken?: string;
   refreshToken?: string;
 }

--- a/src/domain/auth/guards/auth.guard.ts
+++ b/src/domain/auth/guards/auth.guard.ts
@@ -4,5 +4,4 @@ import { AuthGuard } from '@nestjs/passport';
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {}
 @Injectable()
-export class KakaoOAuthGuard extends AuthGuard('kakao') {
-}
+export class KakaoOAuthGuard extends AuthGuard('kakao') {}

--- a/src/domain/auth/strategies/jwt.strategy.ts
+++ b/src/domain/auth/strategies/jwt.strategy.ts
@@ -25,7 +25,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     } as StrategyOptions);
   }
 
-  async validate(payload: any): Promise<JwtPayloadDto> {
-    return payload as JwtPayloadDto; //TODO: 이거 검증되는지 확인
+  async validate(payload: JwtPayloadDto): Promise<JwtPayloadDto> {
+    return payload;
   }
 }

--- a/src/domain/auth/strategies/jwt.strategy.ts
+++ b/src/domain/auth/strategies/jwt.strategy.ts
@@ -5,26 +5,27 @@ import { ConfigService } from '@nestjs/config';
 import { JwtPayloadDto } from '~/src/domain/auth/dto/jwt.dto';
 /* nest 에서 cookie를 다루기위해 express모듈을 사용중임. */
 import { Request } from 'express';
-import { promises } from 'dns';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-    constructor(private readonly configService: ConfigService) {
-        super({
-            /* cookie에 담긴 토큰을 추출 */
-            jwtFromRequest: ExtractJwt.fromExtractors([(req: Request) => {
-              let token = null;
-              if (req && req.cookies) {
-                token = req.cookies['accessToken'];
-              }
-              return token;
-            }]),
-            ignoreExpiration: false,
-            secretOrKey: configService.get<string>('JWT_SECRET'),
-          } as StrategyOptions);
-    }
+  constructor(private readonly configService: ConfigService) {
+    super({
+      /* cookie에 담긴 토큰을 추출 */
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => {
+          let token = null;
+          if (req && req.cookies) {
+            token = req.cookies['accessToken'];
+          }
+          return token;
+        },
+      ]),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_SECRET'),
+    } as StrategyOptions);
+  }
 
-    async validate(payload: any):Promise<JwtPayloadDto> {
-        return payload as JwtPayloadDto; //TODO: 이거 검증되는지 확인
-    }
+  async validate(payload: any): Promise<JwtPayloadDto> {
+    return payload as JwtPayloadDto; //TODO: 이거 검증되는지 확인
+  }
 }

--- a/src/domain/auth/strategies/kakao.strategy.ts
+++ b/src/domain/auth/strategies/kakao.strategy.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { AuthService } from '../auth.service';
 import { ConfigService } from '@nestjs/config';
 import { KakaoProfileDto } from '../dto/social-profile.dto';
+import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 @Injectable()
 export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   constructor(
@@ -22,7 +23,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
       email: profile._json.kakao_account.email,
       name: profile.username,
       socialId: profile.id,
-      socialType: profile.provider,
+      socialType: SocialType.KAKAO,
       accessToken: accessToken,
       refreshToken: refreshToken,
     };

--- a/src/domain/auth/strategies/kakao.strategy.ts
+++ b/src/domain/auth/strategies/kakao.strategy.ts
@@ -24,6 +24,8 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
       name: profile.username,
       socialId: profile.id,
       socialType: SocialType.KAKAO,
+      profileUrl: profile._json.kakao_account.profile.profile_image_url,
+      thumbnailUrl: profile._json.kakao_account.profile.thumbnail_image_url,
       accessToken: accessToken,
       refreshToken: refreshToken,
     };

--- a/src/domain/auth/strategies/kakao.strategy.ts
+++ b/src/domain/auth/strategies/kakao.strategy.ts
@@ -6,24 +6,26 @@ import { ConfigService } from '@nestjs/config';
 import { KakaoProfileDto } from '../dto/social-profile.dto';
 @Injectable()
 export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
-  constructor(private authService: AuthService, private configService: ConfigService) {
+  constructor(
+    private authService: AuthService,
+    private configService: ConfigService,
+  ) {
     super({
       clientID: configService.get('KAKAO_CLIENT_ID'),
-      clientSecret:configService.get('KAKAO_CLIENT_SECRET'),
-      callbackURL:configService.get('KAKAO_CALLBACK_URL'),
+      clientSecret: configService.get('KAKAO_CLIENT_SECRET'),
+      callbackURL: configService.get('KAKAO_CALLBACK_URL'),
     });
-
   }
 
-  async validate(accessToken: string, refreshToken: string, profile: any, done: Function) {
+  async validate(accessToken: string, refreshToken: string, profile: any) {
     const user: KakaoProfileDto = {
       email: profile._json.kakao_account.email,
       name: profile.username,
       socialId: profile.id,
       socialType: profile.provider,
-      accessToken : accessToken,
-      refreshToken : refreshToken
+      accessToken: accessToken,
+      refreshToken: refreshToken,
     };
-    done(null, user);
+    return user;
   }
 }

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -14,6 +14,11 @@ export class CreateUserDto {
   socialId: string;
   @IsString()
   socialType: string;
+
+  @IsString()
+  profile_url: string;
+  @IsString()
+  thumbnail_url: string;
 }
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {}
@@ -29,6 +34,11 @@ export class UserDataDto {
   socialId: string;
   @IsString()
   socialType: string;
+
+  @IsString()
+  profile_url: string;
+  @IsString()
+  thumbnail_url: string;
 }
 
 export class FindBySocialIdDto {

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -1,10 +1,10 @@
-import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 
 export class UserDataDto {
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   id: string;
 
   @IsNotEmpty()
@@ -33,4 +33,8 @@ export class CreateUserDto extends UserDataDto {
   @IsNotEmpty()
   password: string;
 }
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+export class UpdateUserDto extends PartialType(CreateUserDto) {
+  @IsNotEmpty()
+  @IsString()
+  id: string;
+}

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -5,7 +5,7 @@ import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 export class UserDataDto {
   @IsNotEmpty()
   @IsNumber()
-  id: number;
+  id: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -2,28 +2,6 @@ import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 
-export class CreateUserDto {
-  @IsString()
-  name: string;
-  @IsString()
-  email: string;
-  @IsString()
-  @IsNotEmpty()
-  password: string;
-
-  @IsString()
-  socialId: string;
-  @IsString()
-  socialType: SocialType;
-
-  @IsString()
-  profile_url: string;
-  @IsString()
-  thumbnail_url: string;
-}
-
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
-
 export class UserDataDto {
   @IsNumber()
   id: number;
@@ -53,3 +31,11 @@ export class FindByIdDto {
   @IsNumber()
   id: number;
 }
+export class FindByDto extends PartialType(UserDataDto) {}
+
+export class CreateUserDto extends UserDataDto {
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -1,5 +1,6 @@
 import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
+import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 
 export class CreateUserDto {
   @IsString()
@@ -13,7 +14,7 @@ export class CreateUserDto {
   @IsString()
   socialId: string;
   @IsString()
-  socialType: string;
+  socialType: SocialType;
 
   @IsString()
   profile_url: string;
@@ -33,7 +34,7 @@ export class UserDataDto {
   @IsString()
   socialId: string;
   @IsString()
-  socialType: string;
+  socialType: SocialType;
 
   @IsString()
   profile_url: string;
@@ -45,7 +46,7 @@ export class FindBySocialIdDto {
   @IsString()
   socialId: string;
   @IsString()
-  socialType: string;
+  socialType: SocialType;
 }
 
 export class FindByIdDto {

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -1,44 +1,44 @@
-import { IsNumber,IsString,IsNotEmpty } from "class-validator";
+import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 
 export class CreateUserDto {
-    @IsString()
-    name: string;
-    @IsString()
-    email: string;
-    @IsString()
-    @IsNotEmpty()
-    password: string;
+  @IsString()
+  name: string;
+  @IsString()
+  email: string;
+  @IsString()
+  @IsNotEmpty()
+  password: string;
 
-    @IsString()
-    socialId: string;
-    @IsString()
-    socialType: string;
+  @IsString()
+  socialId: string;
+  @IsString()
+  socialType: string;
 }
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {}
 
-export class UserDataDto{
-    @IsNumber()
-    id: number;
-    @IsString()
-    name: string;
-    @IsString()
-    email: string;
-    @IsString()
-    socialId: string;
-    @IsString()
-    socialType: string;
+export class UserDataDto {
+  @IsNumber()
+  id: number;
+  @IsString()
+  name: string;
+  @IsString()
+  email: string;
+  @IsString()
+  socialId: string;
+  @IsString()
+  socialType: string;
 }
 
-export class FindBySocialIdDto{
-    @IsString()
-    socialId: string;
-    @IsString()
-    socialType: string;
+export class FindBySocialIdDto {
+  @IsString()
+  socialId: string;
+  @IsString()
+  socialType: string;
 }
 
-export class FindByIdDto{
-    @IsNumber()
-    id: number;
+export class FindByIdDto {
+  @IsNumber()
+  id: number;
 }

--- a/src/domain/users/dto/user.dto.ts
+++ b/src/domain/users/dto/user.dto.ts
@@ -3,34 +3,29 @@ import { PartialType } from '@nestjs/mapped-types';
 import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 
 export class UserDataDto {
+  @IsNotEmpty()
   @IsNumber()
   id: number;
+
+  @IsNotEmpty()
   @IsString()
   name: string;
+
+  @IsNotEmpty()
   @IsString()
   email: string;
+
   @IsString()
   socialId: string;
   @IsString()
   socialType: SocialType;
 
   @IsString()
-  profile_url: string;
+  profileUrl: string;
   @IsString()
-  thumbnail_url: string;
+  thumbnailUrl: string;
 }
 
-export class FindBySocialIdDto {
-  @IsString()
-  socialId: string;
-  @IsString()
-  socialType: SocialType;
-}
-
-export class FindByIdDto {
-  @IsNumber()
-  id: number;
-}
 export class FindByDto extends PartialType(UserDataDto) {}
 
 export class CreateUserDto extends UserDataDto {

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -6,10 +6,11 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { SocialType } from '~/src/domain/users/enum/social-type.enum';
+
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('uuid')
-  id: number;
+  id: string;
   @Column()
   name: string;
   @Column()

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { SocialType } from '~/src/domain/users/enum/social-type.enum';
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('uuid')
@@ -19,7 +20,7 @@ export class User {
   @Column({ nullable: true })
   socialId: string;
   @Column({ nullable: true })
-  socialType: string;
+  socialType: SocialType;
   // 여기까진 기존의 create-user.dto.ts와 동일합니다.
 
   @Column({ nullable: true })

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -24,9 +24,9 @@ export class User {
   // 여기까진 기존의 create-user.dto.ts와 동일합니다.
 
   @Column({ nullable: true })
-  profile_url: string;
+  profileUrl: string;
   @Column({ nullable: true })
-  thumbnail_url: string;
+  thumbnailUrl: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -22,9 +22,9 @@ export class User {
   socialType: string;
   // 여기까진 기존의 create-user.dto.ts와 동일합니다.
 
-  @Column()
+  @Column({ nullable: true })
   profile_url: string;
-  @Column()
+  @Column({ nullable: true })
   thumbnail_url: string;
 
   @CreateDateColumn()

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -1,23 +1,29 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 @Entity()
 export class User {
-    @PrimaryGeneratedColumn('uuid')
-    id: number;
-    @Column()
-    name: string;
-    @Column()
-    email: string;
-    @Column()
-    password: string;
-    
-    @Column({ nullable: true })
-    socialId: string;
-    @Column({ nullable: true })
-    socialType: string;
-    // 여기까진 기존의 create-user.dto.ts와 동일합니다.
+  @PrimaryGeneratedColumn('uuid')
+  id: number;
+  @Column()
+  name: string;
+  @Column()
+  email: string;
+  @Column()
+  password: string;
 
-    @CreateDateColumn()
-    createdAt: Date;
-    @UpdateDateColumn()
-    updatedAt: Date;  
+  @Column({ nullable: true })
+  socialId: string;
+  @Column({ nullable: true })
+  socialType: string;
+  // 여기까진 기존의 create-user.dto.ts와 동일합니다.
+
+  @CreateDateColumn()
+  createdAt: Date;
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -22,6 +22,11 @@ export class User {
   socialType: string;
   // 여기까진 기존의 create-user.dto.ts와 동일합니다.
 
+  @Column()
+  profile_url: string;
+  @Column()
+  thumbnail_url: string;
+
   @CreateDateColumn()
   createdAt: Date;
   @UpdateDateColumn()

--- a/src/domain/users/enum/social-type.enum.ts
+++ b/src/domain/users/enum/social-type.enum.ts
@@ -1,0 +1,4 @@
+export enum SocialType {
+  KAKAO = 'kakao',
+  NAVER = 'naver',
+}

--- a/src/domain/users/users.controller.ts
+++ b/src/domain/users/users.controller.ts
@@ -1,8 +1,7 @@
-import { Controller} from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { UsersService } from './users.service';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
-
 }

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -20,8 +20,9 @@ export class UsersService {
     return this.makeUserDto(user);
   }
   async findById(findByIdDto: FindByDto) {
+    const { id } = findByIdDto;
     const user = await this.usersRepository.findOne({
-      where: { id: findByIdDto.id },
+      where: { id: id },
     });
     return this.makeUserDto(user);
   }
@@ -37,14 +38,16 @@ export class UsersService {
     return this.makeUserDto(user);
   }
   makeUserDto(user: User) {
+    const { id, name, email, socialId, socialType, profileUrl, thumbnailUrl } =
+      user;
     const userDataDto: UserDataDto = {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      socialId: user.socialId,
-      socialType: user.socialType,
-      profileUrl: user.profileUrl,
-      thumbnailUrl: user.thumbnailUrl,
+      id,
+      name,
+      email,
+      socialId,
+      socialType,
+      profileUrl,
+      thumbnailUrl,
     };
     return userDataDto;
   }

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '~/src/domain/users/entities/user.entity';
 import { Repository } from 'typeorm';
-import {CreateUserDto, FindByIdDto, FindBySocialIdDto, UserDataDto} from '~/src/domain/users/dto/user.dto';
+import {
+  CreateUserDto,
+  FindByIdDto,
+  FindBySocialIdDto,
+  UserDataDto,
+} from '~/src/domain/users/dto/user.dto';
 
 @Injectable()
 export class UsersService {
@@ -10,32 +15,36 @@ export class UsersService {
     @InjectRepository(User)
     private usersRepository: Repository<User>,
   ) {}
-  
+
   async create(createUserDto: CreateUserDto) {
-    const user:User = await this.usersRepository.save(createUserDto);
+    const user: User = await this.usersRepository.save(createUserDto);
     return this.makeUserDto(user);
   }
-  async findById(findByIdDto:FindByIdDto){
-    const user = await this.usersRepository.findOne({where: {id: findByIdDto.id}});
+  async findById(findByIdDto: FindByIdDto) {
+    const user = await this.usersRepository.findOne({
+      where: { id: findByIdDto.id },
+    });
     return this.makeUserDto(user);
   }
 
   async findBySocialId(findBySocialIdDto: FindBySocialIdDto) {
-    const  {socialId, socialType} = findBySocialIdDto;
-    const user:User = await this.usersRepository.findOne({ where: { socialId , socialType} });
-    if(!user){
+    const { socialId, socialType } = findBySocialIdDto;
+    const user: User = await this.usersRepository.findOne({
+      where: { socialId, socialType },
+    });
+    if (!user) {
       return null;
     }
     return this.makeUserDto(user);
   }
-  makeUserDto(user:User){
-    const userDataDto:UserDataDto = {
+  makeUserDto(user: User) {
+    const userDataDto: UserDataDto = {
       id: user.id,
       name: user.name,
       email: user.email,
       socialId: user.socialId,
       socialType: user.socialType,
-    }
+    };
     return userDataDto;
   }
 }

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -4,8 +4,7 @@ import { User } from '~/src/domain/users/entities/user.entity';
 import { Repository } from 'typeorm';
 import {
   CreateUserDto,
-  FindByIdDto,
-  FindBySocialIdDto,
+  FindByDto,
   UserDataDto,
 } from '~/src/domain/users/dto/user.dto';
 
@@ -20,14 +19,14 @@ export class UsersService {
     const user: User = await this.usersRepository.save(createUserDto);
     return this.makeUserDto(user);
   }
-  async findById(findByIdDto: FindByIdDto) {
+  async findById(findByIdDto: FindByDto) {
     const user = await this.usersRepository.findOne({
       where: { id: findByIdDto.id },
     });
     return this.makeUserDto(user);
   }
 
-  async findBySocialId(findBySocialIdDto: FindBySocialIdDto) {
+  async findBySocialId(findBySocialIdDto: FindByDto) {
     const { socialId, socialType } = findBySocialIdDto;
     const user: User = await this.usersRepository.findOne({
       where: { socialId, socialType },
@@ -44,8 +43,8 @@ export class UsersService {
       email: user.email,
       socialId: user.socialId,
       socialType: user.socialType,
-      profile_url: user.profile_url,
-      thumbnail_url: user.thumbnail_url,
+      profileUrl: user.profileUrl,
+      thumbnailUrl: user.thumbnailUrl,
     };
     return userDataDto;
   }

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -44,6 +44,8 @@ export class UsersService {
       email: user.email,
       socialId: user.socialId,
       socialType: user.socialType,
+      profile_url: user.profile_url,
+      thumbnail_url: user.thumbnail_url,
     };
     return userDataDto;
   }

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import {
   CreateUserDto,
   FindByDto,
+  UpdateUserDto,
   UserDataDto,
 } from '~/src/domain/users/dto/user.dto';
 
@@ -36,6 +37,10 @@ export class UsersService {
       return null;
     }
     return this.makeUserDto(user);
+  }
+  async update(updateUserDto: UpdateUserDto) {
+    const { id } = updateUserDto;
+    await this.usersRepository.update(id, updateUserDto);
   }
   makeUserDto(user: User) {
     const { id, name, email, socialId, socialType, profileUrl, thumbnailUrl } =

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,6 @@ async function bootstrap() {
   app.useGlobalFilters(new ServiceExceptionToHttpExceptionFilter());
   app.use(cookieParser());
   setupSwagger(app);
-  
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
- auth 모듈에 exlint 설정적용
- uuid string으로 타입 변경
- 초기 비밀번호 'NOT_DEFINED' 설정
- 기존 모듈의 service 로직 객체 디스트럭쳐링 적용하도록 수정
- Dto 상속관계로 구성하도록 변경 Particial Type 적극 사용
- 소셜 로그인시 이미 존재하는 user라면 name, image url 업데이트 하도록 로직 추가

기존에 service로직 간 데이터를 주고받는 과정에서 객체에 접근하는 방식으로 작성했었습니다. 객체 디스트럭쳐링을 적용하여 service 로직 내 필요한 변수만 const 타입으로 선언하여 분리한뒤 해당 변수를 사용하는 로직으로 변경했습니다. 

Dto는 많이 정의할 수록 좋습니다. 좋은 이유는 필요한 데이터가 변경될시에 dto만 수정해준다면 로직의 수정없이 진행이 가능하다는 점인데 현재 모듈의 코드는 단순히 같은 필드를 여러번 재선언해서 사용하고있습니다. 이러면 하나의 필드가 바뀐다면 ( 타입이나 이름 등등) 다른 Dto를 모두 수정해주어야하는 불편함이 존재했습니다. 이를 상속관계로 묶어 자연스럽게 반영되도록했습니다. 이 과정에서 Partical Type을 적극활용하여 구성했습니다.
