### PR TITLE
fix(auction): 생성순서 수정 Order auction items by creation date

### DIFF
--- a/src/domain/auction/auction-item.repository.ts
+++ b/src/domain/auction/auction-item.repository.ts
@@ -30,7 +30,10 @@ export class AuctionItemRepository extends Repository<AuctionItem> {
   ): Promise<AuctionItem[]> {
     const query = this.createQueryBuilder('auction_item')
       .leftJoinAndSelect('auction_item.user', 'user')
-      .where('auction_item.auction.id = :auctionId', { auctionId });
+      .where('auction_item.auction.id = :auctionId', { auctionId })
+      .orderBy({
+        'auction_item.createdAt': 'ASC',
+      });
 
     if (auctionItemId) {
       query.andWhere('auction_item.id = :auctionItemId', { auctionItemId });

--- a/src/domain/auction/dto/read-auction.dto.ts
+++ b/src/domain/auction/dto/read-auction.dto.ts
@@ -4,7 +4,6 @@ import { User } from '~/src/domain/users/entities/user.entity';
 import { ReadAuctionItemDto } from '~/src/domain/auction/dto/auction-item/read.auction.item.dto';
 import { UserProfileDto } from '~/src/domain/users/dto/user.dto';
 import { JwtPayloadDto } from '~/src/domain/auth/dto/jwt.dto';
-import { AuctionItem } from '../entities/auction-item.entity';
 
 export class ReadUser {
   isOwner: boolean;
@@ -83,9 +82,9 @@ export class AuctionDto extends PickType(Auction, [
   'status',
   'isPrivate',
   'budget',
+  'auctionItems',
 ] as const) {
   user: User;
-  auctionItems?: AuctionItem[];
 
   constructor(auction: Auction, notEndorsed?: boolean) {
     super();
@@ -95,9 +94,7 @@ export class AuctionDto extends PickType(Auction, [
     this.status = auction.status;
     this.isPrivate = auction.isPrivate;
     this.user = auction.user;
-    if (auction?.auctionItems?.length > 0)
-      this.auctionItems = [auction.auctionItems[0]];
-    else this.auctionItems = [];
+    this.auctionItems = auction.auctionItems;
 
     if (!notEndorsed) {
       this.sellingLimitTime = auction.sellingLimitTime;


### PR DESCRIPTION
Added ordering by `createdAt` in `auction-item.repository.ts` to ensure auction items are retrieved in ascending order of their creation date. Also updated `read-auction.dto.ts` to directly assign all auction items rather than selectively assigning the first item.